### PR TITLE
ci: run Playwright CI on the official Docker image (fix install hang)

### DIFF
--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -19,7 +19,21 @@ jobs:
       matrix:
         browser: [chromium, firefox, webkit]
     runs-on: ubuntu-latest
+    # Official Playwright image ships browsers + OS dependencies preinstalled, so no
+    # `playwright install` step is needed (avoids the extract-zip hang on Node 24 in
+    # Playwright < 1.60). Keep the tag in sync with @playwright/test in package.json.
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      # Firefox needs to create a user namespace for its sandbox; the default
+      # seccomp profile on the job container blocks the clone() syscall (EPERM).
+      options: --security-opt seccomp=unconfined
     env:
+      # The container runs as root, but Actions forces HOME=/github/home (owned by
+      # the image's pwuser); Firefox refuses to start as root under another user's
+      # HOME. Point HOME at a root-owned dir to resolve the mismatch.
+      HOME: /root
+      # Image installs browsers here; pin it so resolution is HOME-independent.
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
       BASE_URL: https://www.saucedemo.com/
       STANDARD_USER_USERNAME: standard_user
       STANDARD_USER_PASSWORD: secret_sauce
@@ -45,9 +59,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Install Playwright browser (${{ matrix.browser }})
-        run: npx playwright install --with-deps ${{ matrix.browser }}
 
       - name: Run full regression tests (${{ matrix.browser }})
         run: npm run test:regression:${{ matrix.browser }}

--- a/.github/workflows/pr-review-smoke.yml
+++ b/.github/workflows/pr-review-smoke.yml
@@ -24,7 +24,21 @@ jobs:
       matrix:
         browser: [chromium]
     runs-on: ubuntu-latest
+    # Official Playwright image ships browsers + OS dependencies preinstalled, so no
+    # `playwright install` step is needed (avoids the extract-zip hang on Node 24 in
+    # Playwright < 1.60). Keep the tag in sync with @playwright/test in package.json.
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      # Firefox needs to create a user namespace for its sandbox; the default
+      # seccomp profile on the job container blocks the clone() syscall (EPERM).
+      options: --security-opt seccomp=unconfined
     env:
+      # The container runs as root, but Actions forces HOME=/github/home (owned by
+      # the image's pwuser); Firefox refuses to start as root under another user's
+      # HOME. Point HOME at a root-owned dir to resolve the mismatch.
+      HOME: /root
+      # Image installs browsers here; pin it so resolution is HOME-independent.
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
       BASE_URL: https://www.saucedemo.com/
       STANDARD_USER_USERNAME: standard_user
       STANDARD_USER_PASSWORD: secret_sauce
@@ -51,10 +65,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browser (${{ matrix.browser }})
-        run: npx playwright install --with-deps ${{ matrix.browser }}
-
-      - name: Run critical tests (${{ matrix.browser }})
+      - name: Runcritical tests (${{ matrix.browser }})
         run: npm run test:critical:${{ matrix.browser }}
 
       - name: Upload Allure results
@@ -101,7 +112,21 @@ jobs:
       matrix:
         browser: [chromium, firefox, webkit]
     runs-on: ubuntu-latest
+    # Official Playwright image ships browsers + OS dependencies preinstalled, so no
+    # `playwright install` step is needed (avoids the extract-zip hang on Node 24 in
+    # Playwright < 1.60). Keep the tag in sync with @playwright/test in package.json.
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      # Firefox needs to create a user namespace for its sandbox; the default
+      # seccomp profile on the job container blocks the clone() syscall (EPERM).
+      options: --security-opt seccomp=unconfined
     env:
+      # The container runs as root, but Actions forces HOME=/github/home (owned by
+      # the image's pwuser); Firefox refuses to start as root under another user's
+      # HOME. Point HOME at a root-owned dir to resolve the mismatch.
+      HOME: /root
+      # Image installs browsers here; pin it so resolution is HOME-independent.
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
       BASE_URL: https://www.saucedemo.com/
       STANDARD_USER_USERNAME: standard_user
       STANDARD_USER_PASSWORD: secret_sauce
@@ -128,10 +153,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browser (${{ matrix.browser }})
-        run: npx playwright install --with-deps ${{ matrix.browser }}
-
-      - name: Run smoke tests (${{ matrix.browser }})
+      - name: Runsmoke tests (${{ matrix.browser }})
         run: npm run test:smoke:${{ matrix.browser }}
 
       - name: Upload Allure results
@@ -178,7 +200,21 @@ jobs:
       matrix:
         browser: [chromium, firefox, webkit]
     runs-on: ubuntu-latest
+    # Official Playwright image ships browsers + OS dependencies preinstalled, so no
+    # `playwright install` step is needed (avoids the extract-zip hang on Node 24 in
+    # Playwright < 1.60). Keep the tag in sync with @playwright/test in package.json.
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      # Firefox needs to create a user namespace for its sandbox; the default
+      # seccomp profile on the job container blocks the clone() syscall (EPERM).
+      options: --security-opt seccomp=unconfined
     env:
+      # The container runs as root, but Actions forces HOME=/github/home (owned by
+      # the image's pwuser); Firefox refuses to start as root under another user's
+      # HOME. Point HOME at a root-owned dir to resolve the mismatch.
+      HOME: /root
+      # Image installs browsers here; pin it so resolution is HOME-independent.
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
       BASE_URL: https://www.saucedemo.com/
       STANDARD_USER_USERNAME: standard_user
       STANDARD_USER_PASSWORD: secret_sauce
@@ -205,10 +241,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browser (${{ matrix.browser }})
-        run: npx playwright install --with-deps ${{ matrix.browser }}
-
-      - name: Run API tests (${{ matrix.browser }})
+      - name: RunAPI tests (${{ matrix.browser }})
         run: npm run test:api:${{ matrix.browser }}
 
       - name: Upload Allure results


### PR DESCRIPTION
## Problem

The scheduled **Regression Run** ([example run](https://github.com/AKogut/playwright-ecommerce-framework/actions/runs/27800652586)) timed out at the 45-minute job limit on every browser, every night. The same failure also hit the **Smoke Run**.

Root cause is **not** the tests — it's the *Install Playwright browser* step. `playwright install` downloads the browser to `100%` and then hangs indefinitely during `extract-zip` extraction. This is a known upstream bug affecting **Node.js 24 with Playwright < 1.60** (the download worker dies mid-extraction and the parent hangs on a stale IPC pipe). The repo runs Node 24 with `@playwright/test@1.59.1`, so the install never returns, the tests never start, Playwright's `globalTimeout` never applies, and no report/Allure artifacts are produced.

## Fix

Run the test jobs inside the **official Playwright image** (`mcr.microsoft.com/playwright:v1.59.1-noble`), which ships browsers and OS dependencies preinstalled. This removes the `playwright install` step entirely, so the failing extraction path is never exercised — and the jobs are much faster (≈1 min vs a 45 min hang).

Applied to both workflows in this branch (`nightly-regression.yml` and `pr-review-smoke.yml`):

- **Container image** pinned to the Playwright version in `package.json` (`v1.59.1-noble`).
- `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` so browser resolution stays correct even after `actions/setup-node` runs inside the container.
- `--security-opt seccomp=unconfined` so Firefox can create the user namespace its sandbox needs (otherwise `clone()` returns `EPERM`).
- `HOME=/root` so Firefox does not refuse to start as root under the image user's `HOME` that Actions injects.

## Verification

Dispatched the regression workflow on this branch — all three browsers green, tests actually run:

- chromium: 17 passed · firefox: 17 passed (20.9s) · webkit: 17 passed (22.4s)
- Run: https://github.com/AKogut/playwright-ecommerce-framework/actions/runs/27834920337

Smoke Run (container) also verified green: critical + smoke×3 + api×3 all passed.

## Notes

- The `allure-report` / `deploy` jobs are unchanged — they need only Node, not browsers.
- When `@playwright/test` is upgraded, bump the image tag to match.
- The smoke-workflow change is mirrored here so this branch's own Smoke Run check is green; it is also the subject of #116. Suggested merge order: #116 first, then this PR.