### PR TITLE
ci: run Smoke Run on the official Playwright Docker image

### DIFF
--- a/.github/workflows/pr-review-smoke.yml
+++ b/.github/workflows/pr-review-smoke.yml
@@ -24,7 +24,21 @@ jobs:
       matrix:
         browser: [chromium]
     runs-on: ubuntu-latest
+    # Official Playwright image ships browsers + OS dependencies preinstalled, so no
+    # `playwright install` step is needed (avoids the extract-zip hang on Node 24 in
+    # Playwright < 1.60). Keep the tag in sync with @playwright/test in package.json.
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      # Firefox needs to create a user namespace for its sandbox; the default
+      # seccomp profile on the job container blocks the clone() syscall (EPERM).
+      options: --security-opt seccomp=unconfined
     env:
+      # The container runs as root, but Actions forces HOME=/github/home (owned by
+      # the image's pwuser); Firefox refuses to start as root under another user's
+      # HOME. Point HOME at a root-owned dir to resolve the mismatch.
+      HOME: /root
+      # Image installs browsers here; pin it so resolution is HOME-independent.
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
       BASE_URL: https://www.saucedemo.com/
       STANDARD_USER_USERNAME: standard_user
       STANDARD_USER_PASSWORD: secret_sauce
@@ -51,10 +65,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browser (${{ matrix.browser }})
-        run: npx playwright install --with-deps ${{ matrix.browser }}
-
-      - name: Run critical tests (${{ matrix.browser }})
+      - name: Runcritical tests (${{ matrix.browser }})
         run: npm run test:critical:${{ matrix.browser }}
 
       - name: Upload Allure results
@@ -101,7 +112,21 @@ jobs:
       matrix:
         browser: [chromium, firefox, webkit]
     runs-on: ubuntu-latest
+    # Official Playwright image ships browsers + OS dependencies preinstalled, so no
+    # `playwright install` step is needed (avoids the extract-zip hang on Node 24 in
+    # Playwright < 1.60). Keep the tag in sync with @playwright/test in package.json.
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      # Firefox needs to create a user namespace for its sandbox; the default
+      # seccomp profile on the job container blocks the clone() syscall (EPERM).
+      options: --security-opt seccomp=unconfined
     env:
+      # The container runs as root, but Actions forces HOME=/github/home (owned by
+      # the image's pwuser); Firefox refuses to start as root under another user's
+      # HOME. Point HOME at a root-owned dir to resolve the mismatch.
+      HOME: /root
+      # Image installs browsers here; pin it so resolution is HOME-independent.
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
       BASE_URL: https://www.saucedemo.com/
       STANDARD_USER_USERNAME: standard_user
       STANDARD_USER_PASSWORD: secret_sauce
@@ -128,10 +153,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browser (${{ matrix.browser }})
-        run: npx playwright install --with-deps ${{ matrix.browser }}
-
-      - name: Run smoke tests (${{ matrix.browser }})
+      - name: Runsmoke tests (${{ matrix.browser }})
         run: npm run test:smoke:${{ matrix.browser }}
 
       - name: Upload Allure results
@@ -178,7 +200,21 @@ jobs:
       matrix:
         browser: [chromium, firefox, webkit]
     runs-on: ubuntu-latest
+    # Official Playwright image ships browsers + OS dependencies preinstalled, so no
+    # `playwright install` step is needed (avoids the extract-zip hang on Node 24 in
+    # Playwright < 1.60). Keep the tag in sync with @playwright/test in package.json.
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      # Firefox needs to create a user namespace for its sandbox; the default
+      # seccomp profile on the job container blocks the clone() syscall (EPERM).
+      options: --security-opt seccomp=unconfined
     env:
+      # The container runs as root, but Actions forces HOME=/github/home (owned by
+      # the image's pwuser); Firefox refuses to start as root under another user's
+      # HOME. Point HOME at a root-owned dir to resolve the mismatch.
+      HOME: /root
+      # Image installs browsers here; pin it so resolution is HOME-independent.
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
       BASE_URL: https://www.saucedemo.com/
       STANDARD_USER_USERNAME: standard_user
       STANDARD_USER_PASSWORD: secret_sauce
@@ -205,10 +241,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browser (${{ matrix.browser }})
-        run: npx playwright install --with-deps ${{ matrix.browser }}
-
-      - name: Run API tests (${{ matrix.browser }})
+      - name: RunAPI tests (${{ matrix.browser }})
         run: npm run test:api:${{ matrix.browser }}
 
       - name: Upload Allure results


### PR DESCRIPTION
## Problem

The **Smoke Run** ([example run](https://github.com/AKogut/playwright-ecommerce-framework/actions/runs/27830051868)) timed out at the job limit on the `critical`, `smoke`, and `api` jobs.

Root cause is the *Install Playwright browser* step, not the tests. `playwright install` downloads the browser to `100%` and then hangs during `extract-zip` extraction — a known upstream bug on **Node.js 24 with Playwright < 1.60**. The install never returns, tests never start, and no report/Allure artifacts are produced.

## Fix

Run the `critical`, `smoke`, and `api` jobs inside the **official Playwright image** (`mcr.microsoft.com/playwright:v1.59.1-noble`), which ships browsers + OS dependencies preinstalled. This removes the `playwright install` step entirely, so the failing extraction path is never exercised.

- **Container image** pinned to the Playwright version in `package.json`.
- `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` for HOME-independent browser resolution.
- `--security-opt seccomp=unconfined` so Firefox can create its sandbox user namespace (otherwise `clone()` → `EPERM`).
- `HOME=/root` so Firefox does not refuse to start as root under the image user's HOME.

## Verification

Smoke Run on this branch — all test jobs green: `critical (chromium)`, `smoke (chromium/firefox/webkit)`, `api (chromium/firefox/webkit)` all passed.

- Run: https://github.com/AKogut/playwright-ecommerce-framework/actions/runs/27835054400

## Notes

- The same fix is applied to `nightly-regression.yml` in #115. Suggested merge order: this PR first, then #115.
- When `@playwright/test` is upgraded, bump the image tag to match.